### PR TITLE
Makefile fixes

### DIFF
--- a/client/src/Makefile
+++ b/client/src/Makefile
@@ -1,4 +1,4 @@
 client:
-	gcc -o client client.c
+	gcc -Wall -D_FORTIFY_SOURCE=2 -Wl,-z,relro,-z,now -fPIE -fstack-protector -o client client.c
 clean:
 	rm client


### PR DESCRIPTION
Additional security:

1) Force compilation with stack-guard (add stack cookie to make stack-based buffer overflow exploitation harder)
2) Force FullRELRO to avoid hijacking on relocation entries
3) Force FORTIFY to improve source security
4) Force PIE to randomize binary base